### PR TITLE
Update 2_the-grasshopper-ui.md

### DIFF
--- a/en/1-foundations/1-1/2_the-grasshopper-ui.md
+++ b/en/1-foundations/1-1/2_the-grasshopper-ui.md
@@ -161,9 +161,18 @@ outline type can be defined by right-clicking on any group object.
 >You can also define a group using a meta-ball algorithm by using the Blob Outline profile.
 
 ![IMAGE](images/1-1-2/1-1-2_008-grouping3.png)
->Two groups are nested inside one another. The color (light blue) has been changed on the outer group to help visually identify one group from the other. Groups are drawn “behind” the components within them and, in cases such as this, there is a depth order to the two groups. To change this, go to Edit > Arrange in the main menu bar.
+>Two groups are nested inside one another. The color (light blue) has been changed on the outer group to help visually identify one group from the other. Groups are drawn “behind” the components within them.
 
-####1.1.1.7. WIDGETS
+####1.1.2.6.1 Front-To-Back Ordering
+Although one can (and should) usually arrange components and groups far enough apart that they do not need to overlap, crowding items closer together is manageable using Edit->Arrange from the main menu bar.  You can manipulate the front-to-back order in which overlapped components appear.  The front-to-back order in which overlapped groups appear can also be controlled.
+
+![IMAGE](image/1-1-2/1-1-2_009-depthOrder1.png)
+> A group of related components which could be used to orient a 3D vector is arranged without any overlapping components.
+
+![IMAGE](image/1-1-2/1-1-2_009-depthOrder1.png)
+> The same group is arranged with some overlapping components. The Multi-dimensional Slider has been placed in front of the Decompose-Vector component but behind the Number Slider so that all the user-interface functionality is still available.
+
+####1.1.2.7. WIDGETS
 There are a few widgets that are available in Grasshopper that can help you
 perform useful actions. You can toggle any of these widgets on/off under the
 Display menu of the Main Menu bar. Below we’ll look at a few of the most

--- a/en/1-foundations/1-1/2_the-grasshopper-ui.md
+++ b/en/1-foundations/1-1/2_the-grasshopper-ui.md
@@ -166,10 +166,10 @@ outline type can be defined by right-clicking on any group object.
 ####1.1.2.6.1 Front-To-Back Ordering
 Although one can (and should) usually arrange components and groups far enough apart that they do not need to overlap, crowding items closer together is manageable using Edit->Arrange from the main menu bar.  You can manipulate the front-to-back order in which overlapped components appear.  The front-to-back order in which overlapped groups appear can also be controlled.
 
-![IMAGE](image/1-1-2/1-1-2_009-depthOrder1.png)
+![IMAGE](image/1-1-2/1-1-2_008_5-depthOrder1.png)
 > A group of related components which could be used to orient a 3D vector is arranged without any overlapping components.
 
-![IMAGE](image/1-1-2/1-1-2_009-depthOrder1.png)
+![IMAGE](image/1-1-2/1-1-2_008_5-depthOrder2.png)
 > The same group is arranged with some overlapping components. The Multi-dimensional Slider has been placed in front of the Decompose-Vector component but behind the Number Slider so that all the user-interface functionality is still available.
 
 ####1.1.2.7. WIDGETS


### PR DESCRIPTION
The depth order applies to more than just groups.  It can be used with components too. The previous wording seems to imply that front-to-back ordering only applies "in cases such as this", in other words, to grouped objects which is completely false.

Also, the numbering of item 1.1.1.7 Widgets should have been 1.1.2.7 Widgets to be consistent with the sections prior and after.

But I actually want to retract this pull request.  I did not mean to request this pull (yet). I still have to figure out how to incorporate the new image files into it.

![1-1-2_008_5-depthorder1](https://cloud.githubusercontent.com/assets/562029/9673190/a3481d76-526f-11e5-9db8-dfa0b0d32c05.png)
![1-1-2_008_5-depthorder2](https://cloud.githubusercontent.com/assets/562029/9673191/a34c79b6-526f-11e5-9f2f-e3e465e4eccb.png)